### PR TITLE
Handle invalid console inputs gracefully

### DIFF
--- a/source/console/ConsolePromoter.ixx
+++ b/source/console/ConsolePromoter.ixx
@@ -1,6 +1,7 @@
 module;
 #include <boost/signals2.hpp>
 
+#include <cctype>
 #include <iostream>
 #include <string>
 export module Chess.ConsolePromoter;
@@ -13,6 +14,28 @@ namespace Chess
 {
     export class ConsolePromoter final : public Promoter
     {
+        static char NormalizePromotionChoice(const std::string& input)
+        {
+            for (unsigned char symbol : input)
+            {
+                if (std::isspace(symbol))
+                {
+                    continue;
+                }
+
+                auto normalized = static_cast<char>(std::toupper(static_cast<unsigned char>(symbol)));
+
+                if (normalized == PieceTypeConverter::ConvertToShortString(ePieceType::KING)[0])
+                {
+                    normalized = static_cast<char>(std::tolower(static_cast<unsigned char>(normalized)));
+                }
+
+                return normalized;
+            }
+
+            return '\0';
+        }
+
         static void EnterPromotionType(std::string& input)
         {
             std::getline(std::cin, input);
@@ -28,26 +51,26 @@ namespace Chess
                 std::string input;
                 EnterPromotionType(input);
 
-                input[0] = std::toupper(input[0]);
+                const auto normalized = NormalizePromotionChoice(input);
 
-                if (input[0] == PieceTypeConverter::ConvertToShortString(ePieceType::KING)[0])
+                if (normalized == '\0')
                 {
-                    input[0] = std::tolower(input[0]);
+                    continue;
                 }
 
-                if (input[0] == PieceTypeConverter::ConvertToShortString(ePieceType::BISHOP)[0])
+                if (normalized == PieceTypeConverter::ConvertToShortString(ePieceType::BISHOP)[0])
                 {
                     return ePieceType::BISHOP;
                 }
-                if (input[0] == PieceTypeConverter::ConvertToShortString(ePieceType::KNIGHT)[0])
+                if (normalized == PieceTypeConverter::ConvertToShortString(ePieceType::KNIGHT)[0])
                 {
                     return ePieceType::KNIGHT;
                 }
-                if (input[0] == PieceTypeConverter::ConvertToShortString(ePieceType::QUEEN)[0])
+                if (normalized == PieceTypeConverter::ConvertToShortString(ePieceType::QUEEN)[0])
                 {
                     return ePieceType::QUEEN;
                 }
-                if (input[0] == PieceTypeConverter::ConvertToShortString(ePieceType::ROOK)[0])
+                if (normalized == PieceTypeConverter::ConvertToShortString(ePieceType::ROOK)[0])
                 {
                     return ePieceType::ROOK;
                 }

--- a/source/console/InputHandler.ixx
+++ b/source/console/InputHandler.ixx
@@ -1,7 +1,9 @@
 module;
 #include <boost/signals2.hpp>
 
+#include <cctype>
 #include <iostream>
+#include <string>
 export module Chess.InputHandler;
 import Chess.Coordinate;
 import Chess.eInputType;
@@ -11,13 +13,32 @@ namespace Chess
 {
     export class InputHandler final : public Inputer
     {
+        static char NormalizeFileInput(const std::string& input)
+        {
+            for (unsigned char symbol : input)
+            {
+                if (std::isspace(symbol))
+                {
+                    continue;
+                }
+
+                if (std::isalpha(symbol))
+                {
+                    return static_cast<char>(std::toupper(static_cast<unsigned char>(symbol)));
+                }
+            }
+
+            return '\0';
+        }
+
         char EnterFile() const
         {
             m_signalOnEnter(eInputType::FILE);
 
             std::string input;
             std::getline(std::cin, input);
-            return std::toupper(*input.data());
+
+            return NormalizeFileInput(input);
         }
 
         int EnterRank() const


### PR DESCRIPTION
## Summary
- prevent the input handler from dereferencing empty file entries and filter out the first alphabetic character
- normalise promotion input so empty or whitespace-only responses are ignored instead of causing UB

## Testing
- `python3 build.py` *(fails: unable to clone vcpkg because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_690477d0ba1083289c7d296e29c74de3