### PR TITLE
Make ChessboardPresenter inherit enable_shared_from_this publicly

### DIFF
--- a/source/console/ChessboardPresenter.ixx
+++ b/source/console/ChessboardPresenter.ixx
@@ -19,7 +19,7 @@ import Chess.Sizes;
 
 namespace Chess
 {
-    export class ChessboardPresenter : std::enable_shared_from_this<ChessboardPresenter>
+    export class ChessboardPresenter : public std::enable_shared_from_this<ChessboardPresenter>
     {
         std::shared_ptr<Chessboard> m_chessboard;
 


### PR DESCRIPTION
### Motivation
- `weak_from_this()` in `ChessboardPresenter::Init()` was empty because `ChessboardPresenter` inherited `std::enable_shared_from_this` privately (default for `class`), preventing the shared_ptr machinery from wiring the internal weak state.

### Description
- Change `ChessboardPresenter : std::enable_shared_from_this<ChessboardPresenter>` to `ChessboardPresenter : public std::enable_shared_from_this<ChessboardPresenter>` so `weak_from_this()` and `shared_from_this()` work correctly.

### Testing
- Inspected the modified `source/console/ChessboardPresenter.ixx` and confirmed the inheritance change is present and the file diff shows the single-line update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ee517f0483288003612a7dd2175c)